### PR TITLE
modify fysom requirements version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 slackclient==0.15
 pyyaml==3.11
-fysom==2.1.0
+fysom==2.1.1
 


### PR DESCRIPTION
# Why?
version not found
![screen shot 2015-05-25 at 12 06 49](https://cloud.githubusercontent.com/assets/3915638/7791650/8e48e20e-02d6-11e5-9187-e65f9340b7b5.png)

# How to test?
update version requirement to 2.1.1 and problem fixed!

cc @andyhorng 